### PR TITLE
make sidebar sub-navigation links use pretty URLs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #
@@ -25,15 +25,14 @@ baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://docs.voteamerica.com" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
+permalink: /:path/
 remote_theme: pmarsceill/just-the-docs
 search_enabled: false
 # logo: "/docs/assets/images/logo.png"
 footer_content: "Copyright &copy; VoteAmerica"
 
-
 plugins:
   - jekyll-remote-theme
-
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
Currently, `Action API` in the sidebar links to https://docs.voteamerica.com/api/action.html. With this change, the link will go to https://docs.voteamerica.com/api/action/.