### PR TITLE
Feature/sc 12760/civic data api publish changelog upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,5 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -267,6 +268,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.2

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,6 +23,13 @@ description: >- # this means to ignore newlines until "baseurl:"
   Documentation for VoteAmerica's tools and API.
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://docs.voteamerica.com" # the base hostname & protocol for your site, e.g. http://example.com
+# Set a path/url to a favicon that will be displayed by the browser
+favicon_ico: "/favicon.png"
+
+callouts:
+  highlight:
+    title: Note
+    color: yellow
 
 # Build settings
 permalink: /:path/

--- a/docs/api/deprecated_versions.md
+++ b/docs/api/deprecated_versions.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Deprecated API versions
+parent: API
+has_children: true
+nav_order: 2
+---
+
+# Deprecated API versions
+
+See below for information about previous versions of the Civic Data API. 
+[Find information on the latest version here](/api/).

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,16 +6,19 @@ nav_order: 3
 ---
 
 # VoteAmerica+ APIs
+{: .no_toc }
 
 API keys are only available to VoteAmerica+ customers. 
 Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn more.
 
 ## Interactive API Documents
+{: .no_toc }
 
 To see query request and response examples, visit our interactive interface here: 
 [https://api.voteamerica.com/docs/api/v2](https://api.voteamerica.com/docs/api/v2)
 
 ## Civic Data API
+{: .no_toc }
 
 If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. 
 There are 51 different sets of laws governing elections in the United States 
@@ -23,6 +26,10 @@ because we like to make things as complicated as possible.  We've navigated this
 The data in this API powers the VoteAmerica site and is surfaced throughout the VoteAmerica tools.
 
 [Civic Data API fields and descriptions are here](https://www.voteamerica.com/civic-data-api/).
+
+1. TOC
+{:toc}
+
 
 ### Versions
 
@@ -45,7 +52,10 @@ Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn mo
 For endpoints requiring authentication, use basic auth with your API key ID as the username 
 and API key secret as the password.
 
-### GET `/election/field/`
+### Endpoints
+
+#### GET `/election/field/`
+{: .fs-5 }
 
 **Authentication:** none
 
@@ -78,7 +88,8 @@ Possible field formats include: `Boolean`, `Date`, `Markdown`, `Multi-select`, `
 ]
 ```
 
-### GET `/election/data/state/{state}/`
+#### GET `/election/data/state/{state}/`
+{: .fs-5 }
 
 **Authentication:** basic auth ([details](#authentication))
 
@@ -118,7 +129,8 @@ requires further explanation.
 }
 ```
 
-### GET `/election/override/`
+#### GET `/election/override/`
+{: .fs-5 }
 
 **Authentication:** basic auth ([details](#authentication))
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -47,9 +47,13 @@ and API key secret as the password.
 
 ### GET `/election/field/`
 
-Authentication: none
+**Authentication:** none
 
-Returns an array of state information field objects. Each contains a slug, a longer description, and a field format.
+**Returns:** An array of state information field objects. 
+
+**Notes:** 
+
+Each state information field object contains a slug, a longer description, and a field format.
 Fields using the format `Multi-select` or `Single-select` also include an `options` property that lists the
 possible options available for selection. 
 
@@ -60,6 +64,8 @@ include a list of the options applicable to the state.)
 Slugs can be matched to the results in `/election/data/state/{state}`.
 
 Possible field formats include: `Boolean`, `Date`, `Markdown`, `Multi-select`, `Single-select`, `URL`.
+
+**Response structure:**
 
 ```markdown
 [
@@ -74,10 +80,13 @@ Possible field formats include: `Boolean`, `Date`, `Markdown`, `Multi-select`, `
 
 ### GET `/election/data/state/{state}/`
 
-Authentication: basic auth ([details](#authentication))
+**Authentication:** basic auth ([details](#authentication))
 
-Returns all state information fields for a single state. 
-`{state}` should be a 2-letter postal abbreviation, in upper case.
+**Parameters:** `{state}` should be a 2-letter postal abbreviation, in upper case.
+
+**Returns:** All state information fields for a single state.
+
+**Notes:** 
 
 Each item in the `state_information` list has a `field_type` property that maps to 
 a slug in the `GET /election/field/` response.
@@ -88,8 +97,10 @@ The state's value for a field is returned in 2 different ways:
 boolean value is given, and for Multi-select-format fields, a list is given. For all other field formats, the value
 is provided as a string.
 
-The `footnote` property is populated when the state's value for a given field has exceptions or 
+The `footnotes` property is populated when the state's value for a given field has exceptions or 
 requires further explanation.
+
+**Response structure:**
 
 ```markdown
 {
@@ -107,3 +118,36 @@ requires further explanation.
 }
 ```
 
+### GET `/election/override/`
+
+**Authentication:** basic auth ([details](#authentication))
+
+**Returns:** A list of regional overrides, which are cases where regional-level data (usually representing a county) 
+overrides state-level data. 
+
+**Notes:** 
+
+In a few cases, specific regions within a state have their own value for a field. 
+For example, some cities and counties in Illinois have their own absentee ballot request tool URLs
+(represented by the field `gov_tool_absentee_request`). For voters in these regions, the regional-level URL should
+be used instead of the state-level URL. 
+
+This endpoint returns a list of all regional overrides. For each, the state name, region name, field slug
+and regional-level value is provided.
+
+**Response structure:**
+
+```markdown
+[
+  {
+    "state": string,
+    "region": {
+      "name": string
+    },
+    "field": {
+      "slug": string
+    },
+    "value": string
+  }
+]
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,19 +5,7 @@ has_children: true
 nav_order: 3
 ---
 
-# VoteAmerica+ APIs
-{: .no_toc }
-
-API keys are only available to VoteAmerica+ customers. 
-Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn more.
-
-## Interactive API Documents
-{: .no_toc }
-
-To see query request and response examples, visit our interactive interface here: 
-[https://api.voteamerica.com/docs/api/v2](https://api.voteamerica.com/docs/api/v2)
-
-## Civic Data API
+# VoteAmerica+ Civic Data API
 {: .no_toc }
 
 If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. 
@@ -27,22 +15,30 @@ The data in this API powers the VoteAmerica site and is surfaced throughout the 
 
 [Civic Data API fields and descriptions are here](https://www.voteamerica.com/civic-data-api/).
 
+API keys are only available to VoteAmerica+ customers. 
+Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn more.
+
 1. TOC
 {:toc}
 
-
-### Versions
+## Versions
 
 Version 2 of the Civic Data API is now available. The remainder of this page describes V2. 
 You can find [historic docs for V1 here](/api/v1). 
 Our [Upgrade Guide](/api/upgrade_guide) details all the changes and the rationale behind them.
 
-### Using the API
+## Interactive API Documents
+{: .no_toc }
+
+To see query request and response examples, visit our interactive interface here: 
+[https://api.voteamerica.com/docs/api/v2](https://api.voteamerica.com/docs/api/v2)
+
+## Using the API
 
 The API base URL is `https://api.voteamerica.com/v2/`. 
 For example, you can try running `curl https://api.voteamerica.com/v2/election/field/`.
 
-### Authentication
+## Authentication
 
 Some endpoints (indicated below) require an API key. If you are already a VoteAmerica+ customer with an active
 subscription to the Civic Data API, you can generate an API key 
@@ -52,10 +48,9 @@ Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn mo
 For endpoints requiring authentication, use basic auth with your API key ID as the username 
 and API key secret as the password.
 
-### Endpoints
+## Endpoints
 
-#### GET `/election/field/`
-{: .fs-5 }
+### GET `/election/field/`
 
 **Authentication:** none
 
@@ -88,8 +83,7 @@ Possible field formats include: `Boolean`, `Date`, `Markdown`, `Multi-select`, `
 ]
 ```
 
-#### GET `/election/data/state/{state}/`
-{: .fs-5 }
+### GET `/election/data/state/{state}/`
 
 **Authentication:** basic auth ([details](#authentication))
 
@@ -129,8 +123,7 @@ requires further explanation.
 }
 ```
 
-#### GET `/election/override/`
-{: .fs-5 }
+### GET `/election/override/`
 
 **Authentication:** basic auth ([details](#authentication))
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,44 +1,97 @@
 ---
 layout: default
 title: API
-has_children: false
+has_children: true
 nav_order: 3
 ---
 
 # VoteAmerica+ APIs
 
-API keys are only available to VoteAmerica+ customers. Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn more.
+API keys are only available to VoteAmerica+ customers. 
+Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn more.
 
 ## Interactive API Documents
-Our API docs are currently evolving, but you can get examples, and an interactive interface here: [https://api.voteamerica.com/docs/api/](https://api.voteamerica.com/docs/api/)
+
+To see query request and response examples, visit our interactive interface here: 
+[https://api.voteamerica.com/docs/api/v2](https://api.voteamerica.com/docs/api/v2)
 
 ## Civic Data API
 
-If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. There are 51 different sets of laws governing elections in the United States because we like to make things as complicated as possible.  We've navigated this mess so you don't have to.  The data in this API powers the VoteAmerica site, and is surfaced throughout the VoteAmerica tools.
+If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. 
+There are 51 different sets of laws governing elections in the United States 
+because we like to make things as complicated as possible.  We've navigated this mess so you don't have to.  
+The data in this API powers the VoteAmerica site and is surfaced throughout the VoteAmerica tools.
 
 [Civic Data API fields and descriptions are here](https://www.voteamerica.com/civic-data-api/).
 
+### Versions
+
+Version 2 of the Civic Data API is now available. The remainder of this page describes V2. 
+You can find [historic docs for V1 here](/api/v1). 
+Our [Upgrade Guide](/api/upgrade_guide) details all the changes and the rationale behind them.
+
 ### Using the API
 
-The API base URL is `https://api.voteamerica.com/v1/`. For example, you can try running `curl https://api.voteamerica.com/v1/election/field/`.
+The API base URL is `https://api.voteamerica.com/v2/`. 
+For example, you can try running `curl https://api.voteamerica.com/v2/election/field/`.
 
+### Authentication
+
+Some endpoints (indicated below) require an API key. If you are already a VoteAmerica+ customer with an active
+subscription to the Civic Data API, you can generate an API key 
+[via the VoteAmerica+ Customer Dashboard](https://secure.voteamerica.com/civic-data-api/). 
+Please contact [sales@voteamerica.com](mailto:sales@voteamerica.com) to learn more.
+
+For endpoints requiring authentication, use basic auth with your API key ID as the username 
+and API key secret as the password.
 
 ### GET `/election/field/`
 
 Authentication: none
 
-Returns an array of state information field objects. Each contains a slug, a longer description, and a field format type.
+Returns an array of state information field objects. Each contains a slug, a longer description, and a field format.
+Fields using the format `Multi-select` or `Single-select` also include an `options` property that lists the
+possible options available for selection. 
 
-Slugs can be matched to the results in `/state/{state}`. Descriptions are used as headers on VoteAmerica.com
+(For example: `absentee_request_methods` is a `Multi-select` field that includes
+these options: `["email", "fax", "in_person", "mail", "online", "phone"]`. Each state's value for this field will
+include a list of the options applicable to the state.)
 
+Slugs can be matched to the results in `/election/data/state/{state}`.
+
+Possible field formats include: `Boolean`, `Date`, `Markdown`, `Multi-select`, `Single-select`, `URL`.
+
+```markdown
+[
+  {
+    "slug": string,
+    "description": string,
+    "field_format": string,
+    "options": list (only included for Multi-select and Single-select field formats)
+  }
+]
+```
 
 ### GET `/election/data/state/{state}/`
 
-Auth: basic auth, API key ID as the username and API key secret as the password
+Authentication: basic auth ([details](#authentication))
 
-Returns all elections information fields for a single state. `{state}` should be a 2-letter postal abbreviation, in upper case.
+Returns all state information fields for a single state. 
+`{state}` should be a 2-letter postal abbreviation, in upper case.
 
-```json
+Each item in the `state_information` list has a `field_type` property that maps to 
+a slug in the `GET /election/field/` response.
+
+The state's value for a field is returned in 2 different ways:
+* `text` always gives a string representation of the value.
+* `value` gives the value in a type that varies depending on the field's format. For Boolean-format fields, a 
+boolean value is given, and for Multi-select-format fields, a list is given. For all other field formats, the value
+is provided as a string.
+
+The `footnote` property is populated when the state's value for a given field has exceptions or 
+requires further explanation.
+
+```markdown
 {
     "code": string,
     "name": string,
@@ -46,6 +99,8 @@ Returns all elections information fields for a single state. `{state}` should be
         {
             "text": string,
             "field_type": string,
+            "value": boolean | list | string,
+            "footnotes" string,
             "modified_at": datetime
         }
     ]

--- a/docs/api/upgrade_guide.md
+++ b/docs/api/upgrade_guide.md
@@ -6,6 +6,37 @@ nav_order: 1
 ---
 
 # Upgrading from V1 to V2 of the Civic Data API
+{: .no_toc }
 
 [Version 2](/api) of the VoteAmerica+ Civic Data API is now available. This guide outlines the changes from 
 [Version 1](/api/v1) and their rationale. 
+
+1. TOC
+{:toc}
+
+## New features
+
+### Regional overrides
+
+As if 51 different sets of laws governing elections weren't enough, sometimes specific regions within a state
+do things differently. For instance, the state of Illinois doesn't have just one URL where people across the state
+can request absentee ballots; some cities and counties have their own. 
+
+This is where our new overrides endpoint comes in. It returns a list of override objects, each of which is a case 
+where region-level information should override state-level information. For each, the state name, region name, 
+name of the field being overridden and region-level value is provided. [See the V2 docs](/api/#get-electionoverride) 
+for more information.
+
+* Footnotes
+* Multi-select fields
+* Naming conventions
+
+## Breaking changes
+
+### Renamed property `description`
+
+### Deleted fields
+
+### Renamed fields
+
+### Consolidated fields

--- a/docs/api/upgrade_guide.md
+++ b/docs/api/upgrade_guide.md
@@ -105,68 +105,68 @@ The table below lists all one-to-one renamings of field slugs. In general, the r
 same across the board: To adhere to [more consistent naming conventions](#more-consistent-naming-conventions) 
 as described above.
 
-| V1 name (deprecated)                     | V2 name                                 |
-|:-----------------------------------------|:----------------------------------------|
-| alert_registration                       | alerts_registration                     |
-| alert_vbm                                | alerts_absentee                         |
-| ballot_curing_correction_process         | ballot_curing_directions                |
-| ballot_curing_instructions               | ballot_curing_laws_rejection_reasons    |
-| ballot_curing_notification_process       | ballot_curing_laws_notification_process |
-| emergency_ballot_application             | pdf_emergency_ballot_application        |
-| emergency_ballot_request_end             | emergency_ballot_request_deadline       |
-| emergency_ballot_rules                   | emergency_ballot_laws                   |
-| external_tool_absentee_ballot_tracker    | gov_tool_absentee_tracker               |
-| external_tool_ovr                        | gov_tool_registration                   |
-| external_tool_polling_place              | gov_tool_polling_place                  |
-| external_tool_provisional_ballot_tracker | gov_tool_provisional_tracker            |
-| external_tool_vbm_application            | gov_tool_absentee_request               |
-| external_tool_verify_status              | gov_tool_verify                         |
-| felon_vote_fees                          | felony_laws_restoration_fees            |
-| felon_vote_restoration                   | felony_laws_restoration_timeline        |
-| id_requirements_in_person_registration   | id_laws_in_person_registration          |
-| id_requirements_in_person_voting         | id_laws_in_person_voting                |
-| id_requirements_ovr                      | id_laws_online_registration             |
-| id_requirements_sdr                      | id_laws_sdr                             |
-| id_requirements_students                 | id_laws_student_voters                  |
-| id_requirements_vbm_request              | id_laws_absentee_request                |
-| id_requirements_vbm_return               | id_laws_ballot_return                   |
-| official_info_early_voting               | source_early_voting_info                |
-| official_info_felon                      | source_felony_restoration_info          |
-| official_info_registration               | source_registration_info                |
-| official_info_students                   | source_student_voting_info              |
-| official_info_vbm                        | source_absentee_info                    |
-| official_info_voter_id                   | source_voter_id_info                    |
-| overseas_fvap_directions                 | fvap_directions                         |
-| overseas_fvap_tool                       | gov_tool_uocava                         |
-| registration_automatic_exists            | has_automatic_registration              |
-| registration_minimum_age                 | minimum_age_register                    |
-| registration_nvrf_box_6                  | nvra_directions_box6                    |
-| registration_nvrf_box_7                  | nvra_directions_box7                    |
-| registration_nvrf_box_8                  | nvra_directions_box8                    |
-| registration_nvrf_submission_address     | nvra_address                            |
-| registration_ovr_directions              | registration_directions_online          |
-| registration_rules                       | registration_laws                       |
-| sdr_early_voting                         | has_sdr_early_voting                    |
-| sdr_election_day                         | has_sdr_election_day                    |
-| sdr_where                                | sdr_locations                           |
-| state_election_code                      | source_election_code                    |
-| vbm_absentee_ballot_rules                | absentee_voting_laws                    |
-| vbm_deadline_in_person                   | absentee_deadline_in_person             |
-| vbm_deadline_mail                        | absentee_deadline_mail                  |
-| vbm_deadline_online                      | absentee_deadline_online                |
-| vbm_first_day_to_apply                   | absentee_request_start                  |
-| vbm_no_excuse                            | has_no_excuse_absentee                  |
-| vbm_other_options                        | absentee_ballot_issues                  |
-| vbm_ovbm_directions                      | absentee_directions_online              |
-| vbm_overview                             | absentee_summary                        |
-| vbm_permanent_anyone                     | has_pav_everyone                        |
-| vbm_permanent_disabled                   | has_pav_disabled                        |
-| vbm_request_directions_mail              | absentee_directions_mail                |
-| vbm_state_provides_ballot_postage        | has_free_ballot_postage                 |
-| vbm_universal                            | has_automatic_vbm                       |
-| vbm_voted_ballot_deadline_in_person      | ballot_return_deadline_in_person        |
-| vbm_voted_ballot_deadline_mail           | ballot_return_deadline_mail             |
-| vbm_warnings                             | warnings_absentee                       |
+| V1 name (deprecated)                     | V2 name                                                             |
+|:-----------------------------------------|:--------------------------------------------------------------------|
+| alert_registration                       | alerts_registration                                                 |
+| alert_vbm                                | alerts_absentee                                                     |
+| ballot_curing_correction_process         | ballot_curing_directions                                            |
+| ballot_curing_instructions               | ballot_curing_laws_rejection_reasons                                |
+| ballot_curing_notification_process       | ballot_curing_laws_notification_process                             |
+| emergency_ballot_application             | pdf_emergency_ballot_application                                    |
+| emergency_ballot_request_end             | emergency_ballot_request_deadline                                   |
+| emergency_ballot_rules                   | emergency_ballot_laws                                               |
+| external_tool_absentee_ballot_tracker    | gov_tool_absentee_tracker                                           |
+| external_tool_ovr                        | gov_tool_registration                                               |
+| external_tool_polling_place              | gov_tool_polling_place                                              |
+| external_tool_provisional_ballot_tracker | gov_tool_provisional_tracker                                        |
+| external_tool_vbm_application            | gov_tool_absentee_request                                           |
+| external_tool_verify_status              | gov_tool_verify                                                     |
+| felon_vote_fees                          | felony_laws_restoration_fees                                        |
+| felon_vote_restoration                   | felony_laws_restoration_process                                     |
+| id_requirements_in_person_registration   | id_laws_in_person_registration                                      |
+| id_requirements_in_person_voting         | id_laws_in_person_voting                                            |
+| id_requirements_ovr                      | id_laws_online_registration                                         |
+| id_requirements_sdr                      | id_laws_sdr                                                         |
+| id_requirements_students                 | id_laws_student_voters                                              |
+| id_requirements_vbm_request              | id_laws_absentee_request                                            |
+| id_requirements_vbm_return               | id_laws_ballot_return                                               |
+| official_info_early_voting               | source_early_voting_info                                            |
+| official_info_felon                      | source_rights_restoration_info                                      |
+| official_info_registration               | source_registration_info                                            |
+| official_info_students                   | source_student_voting_info                                          |
+| official_info_vbm                        | source_absentee_info                                                |
+| official_info_voter_id                   | source_voter_id_info                                                |
+| overseas_fvap_directions                 | fvap_uocava_directions                                              |
+| overseas_fvap_tool                       | gov_tool_uocava                                                     |
+| registration_automatic_exists            | has_automatic_registration                                          |
+| registration_minimum_age                 | minimum_age_register                                                |
+| registration_nvrf_box_6                  | nvra_directions_box6                                                |
+| registration_nvrf_box_7                  | nvra_directions_box7                                                |
+| registration_nvrf_box_8                  | nvra_directions_box8                                                |
+| registration_nvrf_submission_address     | nvra_submission_address                                             |
+| registration_ovr_directions              | registration_directions_online                                      |
+| registration_rules                       | registration_laws                                                   |
+| sdr_early_voting                         | has_sdr_early_voting                                                |
+| sdr_election_day                         | has_sdr_election_day                                                |
+| sdr_where                                | sdr_locations                                                       |
+| state_election_code                      | source_election_code                                                |
+| vbm_absentee_ballot_rules                | absentee_voting_laws                                                |
+| vbm_deadline_in_person                   | absentee_deadline_in_person                                         |
+| vbm_deadline_mail                        | absentee_deadline_mail                                              |
+| vbm_deadline_online                      | absentee_deadline_online                                            |
+| vbm_first_day_to_apply                   | absentee_request_start_date                                         |
+| vbm_no_excuse                            | has_no_excuse_absentee                                              |
+| vbm_other_options                        | absentee_ballot_issues                                              |
+| vbm_ovbm_directions                      | absentee_directions_online                                          |
+| vbm_overview                             | absentee_process_summary                                            |
+| vbm_permanent_anyone                     | has_pav_everyone                                                    |
+| vbm_permanent_disabled                   | has_pav_disabled                                                    |
+| vbm_request_directions_mail              | absentee_directions_mail                                            |
+| vbm_state_provides_ballot_postage        | has_free_ballot_postage                                             |
+| vbm_universal                            | has_automatic_vbm                                                   |
+| vbm_voted_ballot_deadline_in_person      | ballot_return_deadline_in_person                                    |
+| vbm_voted_ballot_deadline_mail           | ballot_return_deadline_mail                                         |
+| vbm_warnings                             | warnings_absentee                                                   |
 
 ### Deleted fields
 
@@ -176,9 +176,10 @@ field.
 
 | Deleted field                                   | Rationale / details                                                                                                                                     |
 |-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| early_voting                                    | Redundant with the existence of data in `early_voting_starts` and `early_voting_ends`.                                                                  |
 | early_voting_notes                              | Migrated to footnotes on `early_voting_starts` and `early_voting_ends`.                                                                                 |
 | emergency_ballot_request_start                  | Not necessary to track. Generally, this is when the regular absentee ballot request deadline has passed.                                                |
-| external_tool_felony_restoration_state_info     | Redundant with another field now called `source_felony_restoration_info`.                                                                               |
+| external_tool_felony_restoration_state_info     | Redundant with another field now called `source_rights_restoration_info`.                                                                               |
 | external_tool_vbm_application_requires_printing | Not necessary to track with an independent field. South Carolina is the only state where a ballot request form is available online but must be printed. |
 | external_tool_vbm_has_regional_urls             | No longer needed because the presence of overrides will suggest regional URLs exist.                                                                    |
 | felon_vote_in_prison                            | Consolidated to a `Multi-select` field. If `felon_vote_in_prison` was true, `felony_voting_options` will include `imprisoned`.                          |

--- a/docs/api/upgrade_guide.md
+++ b/docs/api/upgrade_guide.md
@@ -41,7 +41,7 @@ in `footnotes`. [See the V2 docs](/api/#get-electiondatastatestate) for more inf
 ### Multi-select fields
 
 {: .highlight }
-See the [section on consolidated fields](#consolidated-fields) for breaking changes resulting from the move to 
+See the [section on deleted fields](#deleted-fields) for breaking changes resulting from the move to 
 multi-select fields. 
 
 We've added a new field format to the API: `Multi-select`. 

--- a/docs/api/upgrade_guide.md
+++ b/docs/api/upgrade_guide.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Upgrading from V1 to V2
+parent: API
+nav_order: 1
+---
+
+# Upgrading from V1 to V2 of the Civic Data API
+
+[Version 2](/api) of the VoteAmerica+ Civic Data API is now available. This guide outlines the changes from 
+[Version 1](/api/v1) and their rationale. 

--- a/docs/api/upgrade_guide.md
+++ b/docs/api/upgrade_guide.md
@@ -23,20 +23,206 @@ do things differently. For instance, the state of Illinois doesn't have just one
 can request absentee ballots; some cities and counties have their own. 
 
 This is where our new overrides endpoint comes in. It returns a list of override objects, each of which is a case 
-where region-level information should override state-level information. For each, the state name, region name, 
-name of the field being overridden and region-level value is provided. [See the V2 docs](/api/#get-electionoverride) 
-for more information.
+where region-level information should override state-level information. For each override object, 
+the state name, region name, name of the field being overridden and region-level value are provided. 
+[See the V2 docs](/api/#get-electionoverride) for more information.
 
-* Footnotes
-* Multi-select fields
-* Naming conventions
+### Footnotes
+
+As you know, election laws in the United States can be complicated. (Are you detecting a theme here?) 
+Sometimes, a simple date, boolean or string value is not enough to capture the nuance of the situation in a
+particular state. 
+
+For these cases, we've added footnotes. You can find the new `footnotes` property on `state_information` objects
+on the `GET /election/data/state/{state}/` endpoint. Typically, a `state_information` object will include, for 
+the given state, a field and its value. If that value has exceptions or other nuances, those will be explained
+in `footnotes`. [See the V2 docs](/api/#get-electiondatastatestate) for more information.
+
+### Multi-select fields
+
+{: .highlight }
+See the [section on consolidated fields](#consolidated-fields) for breaking changes resulting from the move to 
+multi-select fields. 
+
+We've added a new field format to the API: `Multi-select`. 
+
+This format is useful for cases where there's a finite set of options and each state employs some of them. 
+For example: Absentee ballot request methods. In some states, voters can request a ballot in person, online, 
+or via mail, fax or email. In other states, only in-person and mail requests are available. 
+
+For a field like this (`absentee_request_methods`), you can see the available options via the `GET /election/field` 
+endpoint. If the field format is `Multi-select`, the state information field object will include an `options` property 
+that is a list of all available options. 
+
+Then, when querying a state's data via the `GET /election/data/state/{state}/` endpoint, the state information object 
+will have a `value` that is a list of the options applicable to the state.
+
+### More consistent naming conventions
+
+{: .highlight}
+[See below](#breaking-changes) for information on breaking changes resulting from the new naming conventions.
+
+Version 1 of the VoteAmerica+ Civic Data API grew over time, and some inconsistencies crept in. With the release 
+of V2, we've taking the opportunity to introduce some more consistent naming conventions for our 
+field slugs. For example:
+
+* We are more consistently using the terms `absentee` and `vote-by-mail` in line with 
+[definitions from the League of Women Voters](https://www.lwv.org/blog/knowing-difference-voting-absentee-vs-mail). 
+Per their guidance, we use `absentee` when talking about situations where a voter must request a ballot and
+`vote-by-mail` (shortened to `vbm` in slugs) for cases where all voters automatically receive a ballot in the mail.
+
+* All `Boolean` field slugs start with `is` or `has` so they are more easily recognizable as booleans.
+
+* Each `Boolean` field represents a feature that tends to make voting more accessible, so `true` is a good thing.
+(Ex: `has_sdr_election_day`, when `true`, means the state allows same-day registration on Election Day, 
+which we think is great.)
+
+* Any field representing a URL for an official state tool (ex: online voter registration) starts with `gov_tool`.
+
+* Any field representing a URL that points to official election laws starts with `source`.
+
+* Any field that lists steps a voter should take includes the word `directions`.
+
+* Any field that describes a state's election laws includes the word `laws`.
+
+* Any field that describes a deadline relative to Election Day includes the word `deadline`.
+(Ex: The number of days prior to Election Day when a voter must submit online registration in order to vote
+in that election.)
+
+* In general, we tried to make each slug as short as possible while still clearly describing what it represents.
 
 ## Breaking changes
 
+The sections below describe breaking changes to consider when migrating from V1 to V2 of the Civic Data API.
+
 ### Renamed property `description`
 
-### Deleted fields
+On the `GET /election/field` endpoint, the property `long_name` has been renamed to the more apt `description`.
 
 ### Renamed fields
 
-### Consolidated fields
+The table below lists all one-to-one renamings of field slugs. In general, the rationale for renaming was the
+same across the board: To adhere to [more consistent naming conventions](#more-consistent-naming-conventions) 
+as described above.
+
+| V1 name (deprecated)                     | V2 name                                 |
+|:-----------------------------------------|:----------------------------------------|
+| alert_registration                       | alerts_registration                     |
+| alert_vbm                                | alerts_absentee                         |
+| ballot_curing_correction_process         | ballot_curing_directions                |
+| ballot_curing_instructions               | ballot_curing_laws_rejection_reasons    |
+| ballot_curing_notification_process       | ballot_curing_laws_notification_process |
+| emergency_ballot_application             | pdf_emergency_ballot_application        |
+| emergency_ballot_request_end             | emergency_ballot_request_deadline       |
+| emergency_ballot_rules                   | emergency_ballot_laws                   |
+| external_tool_absentee_ballot_tracker    | gov_tool_absentee_tracker               |
+| external_tool_ovr                        | gov_tool_registration                   |
+| external_tool_polling_place              | gov_tool_polling_place                  |
+| external_tool_provisional_ballot_tracker | gov_tool_provisional_tracker            |
+| external_tool_vbm_application            | gov_tool_absentee_request               |
+| external_tool_verify_status              | gov_tool_verify                         |
+| felon_vote_fees                          | felony_laws_restoration_fees            |
+| felon_vote_restoration                   | felony_laws_restoration_timeline        |
+| id_requirements_in_person_registration   | id_laws_in_person_registration          |
+| id_requirements_in_person_voting         | id_laws_in_person_voting                |
+| id_requirements_ovr                      | id_laws_online_registration             |
+| id_requirements_sdr                      | id_laws_sdr                             |
+| id_requirements_students                 | id_laws_student_voters                  |
+| id_requirements_vbm_request              | id_laws_absentee_request                |
+| id_requirements_vbm_return               | id_laws_ballot_return                   |
+| official_info_early_voting               | source_early_voting_info                |
+| official_info_felon                      | source_felony_restoration_info          |
+| official_info_registration               | source_registration_info                |
+| official_info_students                   | source_student_voting_info              |
+| official_info_vbm                        | source_absentee_info                    |
+| official_info_voter_id                   | source_voter_id_info                    |
+| overseas_fvap_directions                 | fvap_directions                         |
+| overseas_fvap_tool                       | gov_tool_uocava                         |
+| registration_automatic_exists            | has_automatic_registration              |
+| registration_minimum_age                 | minimum_age_register                    |
+| registration_nvrf_box_6                  | nvra_directions_box6                    |
+| registration_nvrf_box_7                  | nvra_directions_box7                    |
+| registration_nvrf_box_8                  | nvra_directions_box8                    |
+| registration_nvrf_submission_address     | nvra_address                            |
+| registration_ovr_directions              | registration_directions_online          |
+| registration_rules                       | registration_laws                       |
+| sdr_early_voting                         | has_sdr_early_voting                    |
+| sdr_election_day                         | has_sdr_election_day                    |
+| sdr_where                                | sdr_locations                           |
+| state_election_code                      | source_election_code                    |
+| vbm_absentee_ballot_rules                | absentee_voting_laws                    |
+| vbm_deadline_in_person                   | absentee_deadline_in_person             |
+| vbm_deadline_mail                        | absentee_deadline_mail                  |
+| vbm_deadline_online                      | absentee_deadline_online                |
+| vbm_first_day_to_apply                   | absentee_request_start                  |
+| vbm_no_excuse                            | has_no_excuse_absentee                  |
+| vbm_other_options                        | absentee_ballot_issues                  |
+| vbm_ovbm_directions                      | absentee_directions_online              |
+| vbm_overview                             | absentee_summary                        |
+| vbm_permanent_anyone                     | has_pav_everyone                        |
+| vbm_permanent_disabled                   | has_pav_disabled                        |
+| vbm_request_directions_mail              | absentee_directions_mail                |
+| vbm_state_provides_ballot_postage        | has_free_ballot_postage                 |
+| vbm_universal                            | has_automatic_vbm                       |
+| vbm_voted_ballot_deadline_in_person      | ballot_return_deadline_in_person        |
+| vbm_voted_ballot_deadline_mail           | ballot_return_deadline_mail             |
+| vbm_warnings                             | warnings_absentee                       |
+
+### Deleted fields
+
+The table below lists all V1 fields that have been deleted in V2. In most cases, this information is still available;
+it was simply redundant with another field or the information has been migrated into footnotes or a `Multi-select`
+field.
+
+| Deleted field                                   | Rationale / details                                                                                                                                     |
+|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| early_voting_notes                              | Migrated to footnotes on `early_voting_starts` and `early_voting_ends`.                                                                                 |
+| emergency_ballot_request_start                  | Not necessary to track. Generally, this is when the regular absentee ballot request deadline has passed.                                                |
+| external_tool_felony_restoration_state_info     | Redundant with another field now called `source_felony_restoration_info`.                                                                               |
+| external_tool_vbm_application_requires_printing | Not necessary to track with an independent field. South Carolina is the only state where a ballot request form is available online but must be printed. |
+| external_tool_vbm_has_regional_urls             | No longer needed because the presence of overrides will suggest regional URLs exist.                                                                    |
+| felon_vote_in_prison                            | Consolidated to a `Multi-select` field. If `felon_vote_in_prison` was true, `felony_voting_options` will include `imprisoned`.                          |
+| felon_vote_notes                                | Migrated to footnotes on `felony_voting_options`.                                                                                                       |
+| felon_vote_parole                               | Consolidated to a `Multi-select` field. If `felon_vote_parole` was true, `felony_voting_options` will include `parole`.                                 |
+| felon_vote_post_sentence                        | Consolidated to a `Multi-select` field. If `felon_vote_post_sentence` was true, `felony_voting_options` will include `post_sentence`.                   |
+| felon_vote_probation                            | Consolidated to a `Multi-select` field. If `felon_vote_probation` was true, `felony_voting_options` will include `probation`.                           |
+| felon_vote_release_prison                       | Redundant with options in `felon_vote_release_prison`.                                                                                                  |
+| id_laws_out_of_state_accepted                   | Too difficult to maintain because of many exceptions.                                                                                                   |
+| id_laws_student_id_accepted                     | Too difficult to maintain because of many exceptions.                                                                                                   |
+| id_requirements_in_person_registration          | Redundant with id_laws_same_day_registration                                                                                                            |
+| overseas_voting                                 | Not necessary to track because it's available in all states.                                                                                            |
+| provisional_voting                              | Not necessary to track because it's available in all states.                                                                                            |
+| registration_directions_felony_conviction       | Most information was redundant with other fields. In general, we want to point folks to Restore Your Vote for detailed information.                     |
+| registration_submission_email                   | Consolidated to a `Multi-select` field. If `registration_submission_email` was true, `registration_methods` will include `email`.                       |
+| registration_submission_fax                     | Consolidated to a `Multi-select` field. If `registration_submission_fax` was true, `registration_methods` will include `fax`.                           |
+| registration_submission_in_person               | Consolidated to a `Multi-select` field. If `registration_submission_in_person` was true, `registration_methods` will include `in_person`.               |
+| registration_submission_mail                    | Consolidated to a `Multi-select` field. If `registration_submission_mail` was true, `registration_methods` will include `mail`.                         |
+| registration_submission_phone                   | Consolidated to a `Multi-select` field. If `registration_submission_phone` was true, `registration_methods` will include `phone`.                       |
+| sdr_notes                                       | Migrated to footnotes on `has_sdr_early_voting`, `has_sdr_election_day` and `sdr_locations`.                                                            |
+| specific_ballot_drop_date                       | Deprecated 2022-specific field.                                                                                                                         |
+| specific_ballot_return_deadline_by_mail         | Deprecated 2022-specific field.                                                                                                                         |
+| specific_ballot_return_deadline_in_person       | Deprecated 2022-specific field.                                                                                                                         |
+| specific_early_voting_ends                      | Deprecated 2022-specific field.                                                                                                                         |
+| specific_early_voting_starts                    | Deprecated 2022-specific field.                                                                                                                         |
+| specific_general_election_date                  | Deprecated 2022-specific field.                                                                                                                         |
+| specific_minimum_dob                            | Deprecated 2022-specific field.                                                                                                                         |
+| specific_official_election_calendar             | Deprecated 2022-specific field.                                                                                                                         |
+| specific_registration_deadline_by_mail          | Deprecated 2022-specific field.                                                                                                                         |
+| specific_registration_deadline_in_person        | Deprecated 2022-specific field.                                                                                                                         |
+| specific_registration_deadline_online           | Deprecated 2022-specific field.                                                                                                                         |
+| specific_vbm_request_deadline_by_in_person      | Deprecated 2022-specific field.                                                                                                                         |
+| specific_vbm_request_deadline_by_mail           | Deprecated 2022-specific field.                                                                                                                         |
+| specific_vbm_request_deadline_online            | Deprecated 2022-specific field.                                                                                                                         |
+| vbm_app_submission_email                        | Consolidated to a `Multi-select` field. If `vbm_app_submission_email` was true, `absentee_request_methods` will include `email`.                        |
+| vbm_app_submission_fax                          | Consolidated to a `Multi-select` field. If `vbm_app_submission_fax` was true, `absentee_request_methods` will include `fax`.                            |
+| vbm_app_submission_in_person                    | Consolidated to a `Multi-select` field. If `vbm_app_submission_in_person` was true, `absentee_request_methods` will include `in_person`.                |
+| vbm_app_submission_mail                         | Consolidated to a `Multi-select` field. If `vbm_app_submission_mail` was true, `absentee_request_methods` will include `mail`.                          |
+| vbm_app_submission_phone                        | Consolidated to a `Multi-select` field. If `vbm_app_submission_phone` was true, `absentee_request_methods` will include `phone`.                        |
+| vbm_counties_provides_dropboxes                 | Too difficult to maintain. See VoteAmerica's Locate tool for the data we have available on dropboxes for specific elections.                            |
+| vbm_notes                                       | Migrated to footnotes on various absentee-related fields.                                                                                               |
+| vbm_return_drop_box                             | Consolidated to a `Multi-select` field. If `vbm_return_drop_box` was true, `ballot_return_locations` will include `drop_box`.                           |
+| vbm_return_early_voting                         | Consolidated to a `Multi-select` field. If `vbm_return_early_voting` was true, `ballot_return_locations` will include `early_voting_site`.              |
+| vbm_return_election_office                      | Consolidated to a `Multi-select` field. If `vbm_return_election_office` was true, `ballot_return_locations` will include `local_election_office`.       |
+| vbm_return_hand_deliver_allowed                 | Redundant with options in `ballot_return_locations`. Only TN and MS won't let you hand-deliver you voted ballot.                                        |
+| vbm_return_polling_place                        | Consolidated to a `Multi-select` field. If `vbm_return_polling_place` was true, `ballot_return_locations` will include `polling_place`.                 |
+| vbm_state_provides_dropboxes                    | Too difficult to maintain. See VoteAmerica's Locate tool for the data we have available on dropboxes for specific elections.                            |

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -9,9 +9,13 @@ nav_order: 1
 # VoteAmerica+ Civic Data API V1
 
 {: .highlight }
-These docs cover a deprecated version of the VoteAmerica+ Civic Data API. [Find information on the latest version here](/api/).
+These docs cover a deprecated version of the VoteAmerica+ Civic Data API. 
+[Find information on the latest version here](/api/).
 
-If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. There are 51 different sets of laws governing elections in the United States because we like to make things as complicated as possible.  We've navigated this mess so you don't have to.  The data in this API powers the VoteAmerica site, and is surfaced throughout the VoteAmerica tools.
+If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. 
+There are 51 different sets of laws governing elections in the United States 
+because we like to make things as complicated as possible.  We've navigated this mess so you don't have to.  
+The data in this API powers the VoteAmerica site, and is surfaced throughout the VoteAmerica tools.
 
 [Civic Data API fields and descriptions are here](https://www.voteamerica.com/civic-data-api/).
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Civic Data API V1
+parent: Deprecated API versions
+grand_parent: API
+nav_order: 1
+---
+
+# Civic Data API V1
+
+{: .highlight }
+These docs cover a deprecated version of the VoteAmerica+ Civic Data API. [Find information on the latest version here](/api/).
+
+If you've ever wanted to build your own Election Center of state-specific data, this is the API for you. There are 51 different sets of laws governing elections in the United States because we like to make things as complicated as possible.  We've navigated this mess so you don't have to.  The data in this API powers the VoteAmerica site, and is surfaced throughout the VoteAmerica tools.
+
+[Civic Data API fields and descriptions are here](https://www.voteamerica.com/civic-data-api/).
+
+## Using the API
+
+The API base URL is `https://api.voteamerica.com/v1/`. For example, you can try running `curl https://api.voteamerica.com/v1/election/field/`.
+
+
+## GET `/election/field/`
+
+Authentication: none
+
+Returns an array of state information field objects. Each contains a slug, a longer description, and a field format type.
+
+Slugs can be matched to the results in `/data/state/{state}`. 
+
+```markdown
+[
+  {
+    "slug": string,
+    "long_name": string,
+    "field_format": string
+  }
+]
+```
+
+
+## GET `/election/data/state/{state}/`
+
+Auth: basic auth, API key ID as the username and API key secret as the password
+
+Returns all elections information fields for a single state. `{state}` should be a 2-letter postal abbreviation, in upper case.
+
+Each `field_type` in the response will match a slug from the GET `/election/field/` query.
+
+```markdown
+{
+    "code": string,
+    "name": string,
+    "state_information": [
+        {
+            "text": string,
+            "field_type": string,
+            "modified_at": datetime
+        }
+    ]
+}
+```
+

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -6,7 +6,7 @@ grand_parent: API
 nav_order: 1
 ---
 
-# Civic Data API V1
+# VoteAmerica+ Civic Data API V1
 
 {: .highlight }
 These docs cover a deprecated version of the VoteAmerica+ Civic Data API. [Find information on the latest version here](/api/).
@@ -22,11 +22,13 @@ The API base URL is `https://api.voteamerica.com/v1/`. For example, you can try 
 
 ## GET `/election/field/`
 
-Authentication: none
+**Authentication:** none
 
-Returns an array of state information field objects. Each contains a slug, a longer description, and a field format type.
+**Returns:** An array of state information field objects. Each contains a slug, a longer description, and a field format type.
 
-Slugs can be matched to the results in `/data/state/{state}`. 
+**Notes:** Slugs can be matched to the results in `/data/state/{state}`. 
+
+**Response structure:**
 
 ```markdown
 [
@@ -41,11 +43,15 @@ Slugs can be matched to the results in `/data/state/{state}`.
 
 ## GET `/election/data/state/{state}/`
 
-Auth: basic auth, API key ID as the username and API key secret as the password
+**Authentication:** basic auth, API key ID as the username and API key secret as the password
 
-Returns all elections information fields for a single state. `{state}` should be a 2-letter postal abbreviation, in upper case.
+**Parameters:** `{state}` should be a 2-letter postal abbreviation, in upper case.
 
-Each `field_type` in the response will match a slug from the GET `/election/field/` query.
+**Returns:** All elections information fields for a single state.
+
+**Notes:** Each `field_type` in the response will match a slug from the GET `/election/field/` query.
+
+**Response structure:**
 
 ```markdown
 {


### PR DESCRIPTION
These are updates to support the release of V2 of the Civic Data API:
* The main "API" page has been updated to reflect version 2
* Documentation on V1 is available on a separate page nested under "Deprecated API versions"
* An Upgrade Guide details the new features and breaking changes

![Screenshot 2023-08-14 at 11 43 03 AM](https://github.com/vote/docs.voteamerica.com/assets/8370527/b4241189-3f0f-45ed-b3aa-c5a17578c6aa)

![API-VoteAmerica-Documentation](https://github.com/vote/docs.voteamerica.com/assets/8370527/d01c2355-65e4-491c-9ae5-ee0ddb164576)

![Upgrading-from-V1-to-V2-VoteAmerica-Documentation](https://github.com/vote/docs.voteamerica.com/assets/8370527/602112a9-62cd-44d1-8f99-2a1f22a552a1)